### PR TITLE
use python integers in a lot of places instead of 64 bit integers

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,5 +1,6 @@
-import torch
+import numpy as np
 import math
+import random
 import itertools
 
 
@@ -9,6 +10,16 @@ import itertools
 # paddings on the left, it gets (1, 0.98, 0.80). Even better, if we add the
 # padding right before the equality sign, ...
 
+def python_integer_randint(low, high, shape):
+    n = math.prod(shape)
+    arr = np.array([random.randrange(low, high) for i in range(n)],
+                   dtype=object).reshape(shape)
+    return arr
+
+def python_integer_bases(base, length):
+    bases = np.array(list(reversed(range(length))), dtype=object)
+    bases = np.expand_dims(np.power(base, bases), 0)
+    return bases
 
 class Dataset:
     def __init__(self, base, number_length, pre_end_padding=0, flip=False):
@@ -33,24 +44,22 @@ class Dataset:
     def make_numbers(self, shape, number_length=None):
         if number_length is None:
             number_length = self.number_length
-        digits = torch.randint(self.base, shape + (number_length,))
-        n_digits = torch.randint(number_length, shape)
-        mask = torch.arange(number_length) < n_digits[..., None]
+        digits = python_integer_randint(0, self.base, shape + (number_length,))
+        n_digits = np.random.randint(0, number_length, shape)
+        mask = np.arange(number_length) < n_digits[..., None]
         digits[mask] = 0
-        bases = torch.pow(self.base, torch.arange(number_length - 1, -1, -1)).unsqueeze(
-            0
-        )
-        return (digits * bases).sum(dim=-1)
+        bases = python_integer_bases(self.base, number_length)
+        result = (digits * bases).sum(axis=-1)
+        m = np.amax(result)
+        return result
 
     def to_digits(self, numbers, length=None):
         if length is None:
             length = self.number_length
 
         # Convert numbers to digits
-        tensor = numbers.unsqueeze(1).repeat(1, length)
-        bases = torch.pow(
-            self.base, torch.arange(length - 1, -1, -1, device=tensor.device)
-        ).unsqueeze(0)
+        tensor = np.tile(np.expand_dims(numbers, 1), (1, length))
+        bases = python_integer_bases(self.base, length)
         digits = (tensor // bases) % self.base
 
         # Mask leading zeros
@@ -58,7 +67,7 @@ class Dataset:
         mask[:, -1] = False
         digits[mask] = self.padding_token
         if self.flip:
-            return torch.flip(digits, [1])
+            return np.flip(digits, [1])
         return digits
 
     def move_padding_to_end(self, tensor, end=True):
@@ -67,17 +76,17 @@ class Dataset:
         # Create a tensor with large values where there's padding and row-wise indices elsewhere
         # This allows us to "sort" the padding to the end, while keeping everything else in its
         # original order.
-        sorting_tensor = torch.where(
+        sorting_tensor = np.where(
             tensor == self.padding_token,
-            tensor.size(1) if end else -tensor.size(1),
-            torch.arange(tensor.size(1), device=tensor.device),
+            tensor.shape[1] if end else -tensor.shape[1],
+            np.arange(tensor.shape[1])
         )
 
         # Get the indices that would sort the tensor
-        _, sorted_indices = sorting_tensor.sort(dim=1)
+        sorted_indices = np.argsort(sorting_tensor, axis=1)
 
         # Use the sorted indices to rearrange the original tensor
-        sorted_tensor = torch.gather(tensor, 1, sorted_indices)
+        sorted_tensor = np.take_along_axis(tensor, sorted_indices, 1)
 
         return sorted_tensor
 
@@ -87,7 +96,7 @@ class Dataset:
         res = self.move_padding_to_end(res)
         res[res == self.n_tokens] = self.padding_token
         assert res.shape == (bs, self.seq)
-        return res
+        return res.astype(int)
 
     def _generate_batch(self, tokens):
         assert False, "Not implemented"
@@ -128,20 +137,20 @@ class AddModDataset(Dataset):
     def _generate_batch(self, bs):
         a, b = self.make_numbers((2, bs))
         c = self.make_numbers((bs,), (self.number_length + 1) // 2)
-        out = (a + b) % torch.clip(c, min=1)
-        return torch.cat(
+        out = (a + b) % np.clip(c, 1, None)
+        return np.concatenate(
             [
-                torch.full((bs, 1), self.start_token),
+                np.full((bs, 1), self.start_token),
                 self.to_digits(a),
-                torch.full((bs, 1), self.separator_token),
+                np.full((bs, 1), self.separator_token),
                 self.to_digits(b),
-                torch.full((bs, 1), self.separator_token2),
+                np.full((bs, 1), self.separator_token2),
                 self.to_digits(c),
-                torch.full((bs, 1), self.end_token),
+                np.full((bs, 1), self.end_token),
                 self.to_digits(out),
-                torch.full((bs, 1), self.eos_token),
+                np.full((bs, 1), self.eos_token),
             ],
-            dim=1,
+            axis=1,
         )
 
     @property
@@ -170,19 +179,19 @@ class BinaryOpDataset(Dataset):
 
     def _generate_batch(self, bs):
         a, b = self.make_numbers((2, bs))
-        b = torch.clip(b, min=self.min_b)
+        b = np.clip(b, self.min_b, None)
         out = self.func(a, b)
-        return torch.cat(
+        return np.concatenate(
             [
-                torch.full((bs, 1), self.start_token),
+                np.full((bs, 1), self.start_token),
                 self.to_digits(a),
-                torch.full((bs, 1), self.separator_token),
+                np.full((bs, 1), self.separator_token),
                 self.to_digits(b),
-                torch.full((bs, 1), self.end_token),
+                np.full((bs, 1), self.end_token),
                 self.to_digits(out, length=self.out_length),
-                torch.full((bs, 1), self.eos_token),
+                np.full((bs, 1), self.eos_token),
             ],
-            dim=1,
+            axis=1,
         )
 
     @property
@@ -206,22 +215,22 @@ class DivModDataset(Dataset):
 
     def _generate_batch(self, bs):
         a, b = self.make_numbers((2, bs), self.base)
-        b = torch.clip(b, min=1)
+        b = np.clip(b, 1, None)
         div = a // b
         mod = a % b
-        return torch.cat(
+        return np.concatenate(
             [
-                torch.full((bs, 1), self.start_token),
+                np.full((bs, 1), self.start_token),
                 self.to_digits(a),
-                torch.full((bs, 1), self.separator_token),
+                np.full((bs, 1), self.separator_token),
                 self.to_digits(b),
-                torch.full((bs, 1), self.end_token),
+                np.full((bs, 1), self.end_token),
                 self.to_digits(div),
-                torch.full((bs, 1), self.output_separator),
+                np.full((bs, 1), self.output_separator),
                 self.to_digits(mod),
-                torch.full((bs, 1), self.eos_token),
+                np.full((bs, 1), self.eos_token),
             ],
-            dim=1,
+            axis=1,
         )
 
     @property
@@ -240,13 +249,13 @@ class FactorDataset(Dataset):
         if self.primes_length == number_length:
             return self.primes
         n = self.base**self.number_length
-        sieve = torch.ones(n, dtype=torch.bool)
+        sieve = np.ones(n, dtype=bool)
         # We include 1, but not 0
         sieve[0] = False
         for i in range(2, n):
             if sieve[i]:
                 sieve[i * i :: i] = False
-        self.primes = torch.nonzero(sieve).squeeze()
+        self.primes = np.squeeze(np.nonzero(sieve))
         self.primes_length = self.number_length
         return self.primes
 
@@ -265,43 +274,43 @@ class FactorDataset(Dataset):
         primes = self.get_primes(self.number_length)
         # A random number contains the factor p with probability 1/p
         weights = 1 / primes
-        indices = torch.multinomial(
-            weights, num_samples=bs * self.max_factors, replacement=True
-        )
-        sampled_primes = primes[indices].reshape(bs, self.max_factors)
+        num_samples = bs * self.max_factors
+        sampled_primes = random.choices(primes, weights=weights, k=num_samples)
+        sampled_primes = np.array(sampled_primes, dtype=object)
+        sampled_primes = np.reshape(sampled_primes, (bs, self.max_factors))
         # Products may be too large. Let's fix that
         while True:
-            log_prods = torch.sum(torch.log(sampled_primes), dim=1)
+            log_prods = np.sum(np.log(sampled_primes.astype(float)), axis=1)
             mask = log_prods > math.log(self.base) * self.number_length
             num_too_large = mask.sum().item()
             if num_too_large == 0:
                 break
             # Update the first non-one value in the rows that are too large
-            non_one_indices = (sampled_primes != 1).long()
+            non_one_indices = (sampled_primes != 1).astype(int)
             first_non_one_mask = (
-                torch.cumsum(non_one_indices, dim=1) == 1
-            ) & mask.unsqueeze(-1)
+                np.cumsum(non_one_indices, axis=1) == 1
+            ) & np.expand_dims(mask, -1)
             sampled_primes[first_non_one_mask] = 1
 
         filtered_primes = sampled_primes
-        prods = torch.prod(filtered_primes, dim=1)
-        filtered_primes = filtered_primes.sort(dim=1).values
+        prods = np.prod(filtered_primes, axis=1)
+        filtered_primes = np.sort(filtered_primes, axis=1)
         parts = [
-            torch.full((bs, 1), self.start_token),
+            np.full((bs, 1), self.start_token),
             self.to_digits(prods),
-            torch.full((bs, 1), self.end_token),
+            np.full((bs, 1), self.end_token),
         ]
         for i in range(self.max_factors):
             parts += [
                 self.to_digits(filtered_primes[:, i]),
-                torch.full((bs, 1), self.separator_token),
+                np.full((bs, 1), self.separator_token),
             ]
             # If 1, change it to padding
             parts[-2][filtered_primes[:, i] == 1] = self.padding_token
             parts[-1][filtered_primes[:, i] == 1] = self.padding_token
         # Replace last separator with EOS
-        parts[-1] = torch.full((bs, 1), self.eos_token)
-        res = torch.cat(parts, dim=1)
+        parts[-1] = np.full((bs, 1), self.eos_token)
+        res = np.concatenate(parts, axis=1)
         res = self.move_padding_to_end(res)
         res = res[:, : self.seq]
         return res

--- a/dataset.py
+++ b/dataset.py
@@ -1,6 +1,6 @@
 import numpy as np
 import math
-import random
+from random import randrange, choice
 import itertools
 
 
@@ -9,12 +9,6 @@ import itertools
 # kind=transformer-lstm gets accuracies (1, 0.95, 0.66), but we just five extra
 # paddings on the left, it gets (1, 0.98, 0.80). Even better, if we add the
 # padding right before the equality sign, ...
-
-def python_integer_randint(low, high, shape):
-    n = math.prod(shape)
-    arr = np.array([random.randrange(low, high) for i in range(n)],
-                   dtype=object).reshape(shape)
-    return arr
 
 def python_integer_bases(base, length):
     bases = np.array(list(reversed(range(length))), dtype=object)
@@ -44,13 +38,9 @@ class Dataset:
     def make_numbers(self, shape, number_length=None):
         if number_length is None:
             number_length = self.number_length
-        digits = python_integer_randint(0, self.base, shape + (number_length,))
-        n_digits = np.random.randint(0, number_length, shape)
-        mask = np.arange(number_length) < n_digits[..., None]
-        digits[mask] = 0
-        bases = python_integer_bases(self.base, number_length)
-        result = (digits * bases).sum(axis=-1)
-        m = np.amax(result)
+        tenpowers = [10**(i+1) for i in range(number_length)]
+        n = math.prod(shape)
+        result = np.array([randrange(choice(tenpowers)) for i in range(n)], dtype=object).reshape(shape)
         return result
 
     def to_digits(self, numbers, length=None):

--- a/model.py
+++ b/model.py
@@ -276,7 +276,8 @@ class AdditionModel(nn.Module):
 
     @torch.no_grad()
     def print_examples(self, num_examples=3, must_include_a_wrong=False):
-        examples = self.ds.generate_batch(num_examples).to(self.embedding.weight.device)
+        np_examples = self.ds.generate_batch(num_examples)
+        examples = torch.tensor(np_examples).to(self.embedding.weight.device)
         i = 0
         while i < num_examples:
             example = examples[i]
@@ -287,7 +288,8 @@ class AdditionModel(nn.Module):
             is_correct = torch.all(true_answer == raw_prediction)
             # Get at least one wrong example each time
             if is_correct and i == num_examples - 1 and must_include_a_wrong:
-                examples[i] = self.ds.generate_batch(1)[0]
+                np_examples = self.ds.generate_batch(1)
+                examples[i] = torch.tensor(np_examples)[0]
                 continue
             print("Example:", self.ds.repr_example(example))
             print(

--- a/train.py
+++ b/train.py
@@ -75,6 +75,11 @@ def main():
         type=int,
         default=10,
     )
+    parser.add_argument(
+        "--initial-number-length",
+        type=int,
+        default=1,
+    )
     parser.add_argument("--compile", action="store_true")
     parser.add_argument("--flip", action="store_true", help="Flip order of numbers")
     parser.add_argument("--device", type=str, default=None)
@@ -86,7 +91,7 @@ def main():
     )
     args = parser.parse_args()
 
-    dataset = make_dataset(args)
+    dataset = make_dataset(args, number_length=args.initial_number_length)
 
     model = AdditionModel(
         ds=dataset,
@@ -227,7 +232,8 @@ def manual_training(model, dataset, args):
     for epoch in range(args.epochs):
         train_batches = 1000
         with torch.no_grad():
-            train_data = dataset.generate_batch(batch_size * train_batches).to(device)
+            np_data = dataset.generate_batch(batch_size * train_batches)
+            train_data = torch.tensor(np_data).to(device)
 
         # Training Loop
         model.train()
@@ -243,7 +249,8 @@ def manual_training(model, dataset, args):
         model.eval()
         with torch.no_grad():
             val_batches = 100
-            val_data = dataset.generate_batch(batch_size * val_batches).to(device)
+            np_data = dataset.generate_batch(batch_size * train_batches)
+            val_data = torch.tensor(np_data).to(device)
 
             for batch_idx in tqdm.tqdm(range(val_batches)):
                 batch = val_data[batch_idx * batch_size : (batch_idx + 1) * batch_size]

--- a/train.py
+++ b/train.py
@@ -80,6 +80,12 @@ def main():
         type=int,
         default=1,
     )
+    parser.add_argument(
+        "--preferred-dtype",
+        type=str,
+        default='int64',
+        help="Use this dtype if possible (int64, object)"
+    )
     parser.add_argument("--compile", action="store_true")
     parser.add_argument("--flip", action="store_true", help="Flip order of numbers")
     parser.add_argument("--device", type=str, default=None)
@@ -113,6 +119,7 @@ def main():
 
 def make_dataset(args, number_length=1):
     kvargs = dict(
+        preferred_dtype=args.preferred_dtype,
         base=args.base,
         number_length=number_length,
         pre_end_padding=args.cot_padding,


### PR DESCRIPTION
The dataset module now uses numpy instead of torch. Most datasets are now created with Python integers, so you can add bigger numbers that would overflow 64 bits. It still uses small integers for factoring because of how the sieve worked.